### PR TITLE
Add github action to sync with Suite

### DIFF
--- a/.github/workflows/bot-suite-sync.yml
+++ b/.github/workflows/bot-suite-sync.yml
@@ -1,0 +1,49 @@
+name: "[Bot] Update GitBook revision in Suite"
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  update-revision-in-suite:
+    if: github.event.head_commit.committer.username == 'gitbook-bot'
+    
+    env:
+      SUITE_REPO: "trezor/trezor-suite"
+      SUITE_BRANCH: "develop"
+      FILEPATH: "./packages/suite-data/src/guide/constants.ts"
+      PR_BRANCH: "chore/update-suite-guide"
+      GITHUB_TOKEN: ${{ secrets.TREZOR_BOT_TOKEN }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout trezor-suite repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ env.SUITE_REPO }}
+          ref: ${{ env.SUITE_BRANCH }}
+          fetch-depth: 0
+          token: ${{ secrets.TREZOR_BOT_TOKEN }}
+
+      - name: Create a new branch and switch to it
+        run: git switch -C ${{ env.PR_BRANCH }}
+
+      - name: Update GitBook revision
+        run: sed -i "s/^export const GITBOOK_REVISION = .*/export const GITBOOK_REVISION = '${{ github.sha }}'/" ${{ env.FILEPATH }}
+
+      - name: Stage and commit
+        run: |
+          git config user.name "trezor-ci"
+          git config user.email "${{ secrets.TREZOR_BOT_EMAIL }}"
+          git add ${{ env.FILEPATH }}
+          git commit -m "chore(suite-data): update guide revision"
+
+      - name: Force push
+        run: git push --force --set-upstream origin ${{ env.PR_BRANCH }}
+
+      - name: Create pull request
+        if: github.ref == 'refs/heads/master'
+        run: gh pr create --repo ${{ env.SUITE_REPO }} --base ${{ env.SUITE_BRANCH }} --head ${{ env.PR_BRANCH }} --title "GitBook revision update" --label "guide" --body "Automatically generated PR to update GitBook revision, i.e. to sync the latest [trezor-suite-guide](https://github.com/${{ github.repository }}) content to Suite. Before merging, check its [commit history](https://github.com/trezor/${{ github.repository }}/master). Once the pipeline finishes, you can check the result [here](https://suite.corp.sldev.cz/suite-web/${{ env.PR_BRANCH }}/web/)."

--- a/README.md
+++ b/README.md
@@ -39,4 +39,8 @@ Please delete unused images. Otherwise, they are unnecessarily bundled with the 
 
 ## How to publish
 
-The contents of this GitBook are packaged with each release of Suite applicaiton. The version is controlled from within Suite's codebase. To propagate your latest changes to the next relase ask Suite dev team to update the `GB_REVISION` configuration constant in the `suite-data` package.
+The contents of this GitBook are packaged with each release of Suite application. The version is controlled from within Suite's codebase via the `GITBOOK_REVISION` constant in the `suite-data` package. After data sync from the GitBook platform to this repo, a GitHub action to update the constant in Suite is triggered. Once the pipeline finishes, you can check the result in Suite [dev environment](https://suite.corp.sldev.cz/suite-web/chore/update-suite-guide/web/). If the GitBook content was synced to the `master` branch of this repository, a pull request is automatically created in the Suite repo to be checked by the devs and to make its way into production with the next release.
+
+## Testing in Suite
+
+Sometimes, you might want to see your changes in Suite UI without publishing them. The process is the same as publishing, but the GitBook project must sync into the `develop` branch instead of `master` so that it does not create a pull request.


### PR DESCRIPTION
An action to automate updating GitBook revision in Suite. I tested it in a forked repo, not sure it will work with the permissions setup on this account. Please take a look @matejkriz @vdovhanych.

The idea is to automate this task for @alex-jerechinsky and @b-irving so that they do not have to touch GitHub. It should work like this:

Once content is synced from Gitbook, update `GITBOOK_REVISION` in Suite. This should start Suite pipeline and the result can soon be checked by the writer. If the content was synced to `master` branch, create a pull request in Suite repo.