### PR TITLE
fix: Ignore VPN domain for URL check

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,1 @@
+^https://.*\.corp\.sldev\.cz/


### PR DESCRIPTION
CI test content is failing because of not having whiletested sldev url